### PR TITLE
docs: sync windsurf workflows and rules from career repo

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,8 +1,0 @@
-{
-  "default": true,
-  "MD013": false,
-  "MD022": false,
-  "MD031": false,
-  "MD032": false,
-  "MD040": false
-}

--- a/.windsurf/rules/git_workflow_rules.md
+++ b/.windsurf/rules/git_workflow_rules.md
@@ -48,6 +48,8 @@ version: revert   # Reverting changes
 
 ## Testing
 
+<!-- Include testing section only for code changes that require testing -->
+<!-- For documentation changes (docs:), style changes (style:), or chore changes, omit this section -->
 - [ ] I have tested these changes locally using `act`
 - [ ] All existing tests pass
 - [ ] My commits are signed with GPG"

--- a/.windsurf/workflows/branch-write-review-ship.md
+++ b/.windsurf/workflows/branch-write-review-ship.md
@@ -1,0 +1,82 @@
+---
+description: Branch, write, review, and ship notes or ideas following full project conventions
+---
+
+# Workflow: Branch, Write, Review, Ship
+
+Use this workflow any time you want to capture and ship notes, ideas, quotes, or documentation following full project conventions (branching, human review, CI, merge, version bump).
+
+## Steps
+
+1. Create a new date-prefixed branch reflecting the desired addition(s):
+
+   ```bash
+   git checkout -b $(date +%Y.%m.%d)/descriptive-branch-name && git push --set-upstream origin $(date +%Y.%m.%d)/descriptive-branch-name
+   ```
+
+2. Create or update the relevant notes file with the new content.
+
+3. **Pause here** — give the human time to review the added content, confirm it looks right, and resolve any linter warnings before proceeding.
+
+4. When the human gives the go-ahead, review all changes and create appropriate commits for all changed/unstaged items:
+   - Stage only the relevant files
+   - Use a semantic commit message (`docs:`, `feat:`, etc.)
+   - Sign the commit with GPG (`git commit -S`)
+
+5. Push the branch and create a PR:
+
+   ```bash
+   gh pr create --title "docs: <description>" --body "..."
+   ```
+
+   - PR title must follow semantic versioning conventions (enforced by CI)
+   - Use `version: docs` in the PR body for documentation-only changes
+
+6. Walk the human through the diff — **do this before watching CI**:
+
+   Pull the full diff and review it with the human in meaningful units (not necessarily line-by-line, but grouped by logical change). For each unit, explain:
+
+   - **What changed** — describe the specific addition, removal, or modification
+   - **Why it changed** — the intent or reasoning behind it
+   - **How to validate it** — one of:
+     - *Manual human review* (e.g., "read this section and confirm the framing is accurate")
+     - *Automated test* (e.g., "run `npm test` to verify the workflow linting passes")
+     - *Both* where appropriate
+
+   To pull the diff for review:
+
+   ```bash
+   gh pr diff <PR_NUMBER>
+   ```
+
+7. Watch GitHub CI/CD:
+
+   ```bash
+   gh pr checks <PR_NUMBER> --watch
+   ```
+
+   - If CI passes, merge the PR and delete the remote branch:
+
+     ```bash
+     gh pr merge <PR_NUMBER> --merge --delete-branch
+     ```
+
+   - If CI fails, investigate and fix before merging
+
+8. Switch to `main` and watch CI for the automated version bump commit to land:
+
+   ```bash
+   git checkout main
+   ```
+
+   Then watch the post-merge CI run on `main` (the version bump workflow runs after merge):
+
+   ```bash
+   gh run watch $(gh run list --branch main --workflow version-bump.yml --limit 1 --json databaseId --jq '.[0].databaseId')
+   ```
+
+   Only after the version bump CI completes successfully, pull the latest code:
+
+   ```bash
+   git pull
+   ```


### PR DESCRIPTION
# Description

Syncs `starting-point` with improvements made in the `career` repo:

- **Add** `branch-write-review-ship.md` Windsurf workflow — a general-purpose workflow for branching, writing, reviewing, and shipping notes or ideas following full project conventions
- **Remove** `add-interview-notes.md` (replaced by the renamed workflow above)
- **Remove** `.markdownlint.json` — was disabling MD013, MD022, MD031, MD032, and MD040; removed to use default markdownlint rules matching `career`
- **Update** `git_workflow_rules.md` — adds testing section comments clarifying when the testing checklist applies

## Type of Change

version: docs     # Documentation changes